### PR TITLE
ci: Adds [SKIP] to bot commit messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,10 @@ jobs:
         run: |
           git checkout -b $HEAD
           git add package.json
-          git commit -m "[bot] ts release $APP $NEW_VERSION"
+          git commit -m "[bot] ts release $APP $NEW_VERSION [SKIP]"
           git push --set-upstream origin $HEAD
           url=$(gh pr create \
-            --title '[bot] release ${{ env.VERSION }}' \
+            --title '[bot] release ${{ env.VERSION }} [SKIP]' \
             --body 'This PR bumps the version to ${{ env.VERSION }}')
           echo "URL=$(echo $url)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This change should stop the infinite release loop as the commit messages/PR title will have the [SKIP] label present, which is checked in the `details` step.