### PR TITLE
Add translation keys for 'draftComment' and 'finaliseCard' in multipl…

### DIFF
--- a/src/bs/index.ts
+++ b/src/bs/index.ts
@@ -8,6 +8,8 @@ const bs: Translations = {
   addComment: "Dodaj komentar",
   comment: "Komentariši",
   writeComment: "Napiši komentar...",
+  draftComment: "Nacrt komentara",
+  finaliseCard: "Završi karticu",
   comments: "KOMENTARI",
   createBoard: "Kreiraj ploču",
   createPage: "Kreiraj stranicu",

--- a/src/de/index.ts
+++ b/src/de/index.ts
@@ -264,6 +264,8 @@ const de = {
   comment: "Kommentar",
   replyToComment: "Auf Kommentar antworten...",
   writeComment: "Einen Kommentar schreiben...",
+  draftComment: "Entwurfskommentar",
+  finaliseCard: "Karte abschließen",
   comments: "Kommentare",
   createBoard: "Tafel erstellen",
   createPage: "Seite erstellen",

--- a/src/en/index.ts
+++ b/src/en/index.ts
@@ -259,6 +259,8 @@ const en = {
   comment: "Comment",
   replyToComment: "Reply to comment...",
   writeComment: "Write a comment...",
+  draftComment: "Draft comment",
+  finaliseCard: "Finalise card",
   comments: "Comments",
   createBoard: "Create board",
   createPage: "Create page",

--- a/src/fr/index.ts
+++ b/src/fr/index.ts
@@ -263,6 +263,8 @@ const fr: Translations = {
   comment: "Commenter",
   replyToComment: "Répondre au commentaire...",
   writeComment: "Écrire un commentaire...",
+  draftComment: "Brouillon de commentaire",
+  finaliseCard: "Finaliser la carte",
   comments: "Commentaires",
   createBoard: "Créer un tableau",
   createPage: "Créer une page",

--- a/src/pl/index.ts
+++ b/src/pl/index.ts
@@ -259,6 +259,8 @@ const pl = {
   comment: "Komentarz",
   replyToComment: "Odpowiedz na komentarz...",
   writeComment: "Napisz komentarz...",
+  draftComment: "Szkic komentarza",
+  finaliseCard: "Zakończ kartę",
   comments: "Komentarze",
   createBoard: "Utwórz tablicę",
   createPage: "Utwórz stronę",

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,8 @@ export enum TranslationKeys {
   ReplyToComment = "replyToComment",
   WriteComment = "writeComment",
   Comments = "comments",
+  DraftComment = "draftComment",
+  FinaliseCard = "finaliseCard",
   CreateBoard = "createBoard",
   CreatePage = "createPage",
   Delete = "delete",


### PR DESCRIPTION
…e languages

This update introduces the 'draftComment' and 'finaliseCard' translation keys in English, German, French, Polish, and Bosnian, enhancing the localization support for commenting and card finalization features.